### PR TITLE
Can now been set to 0/off

### DIFF
--- a/src/HitableBehavior.php
+++ b/src/HitableBehavior.php
@@ -68,7 +68,7 @@ class HitableBehavior extends Behavior
      */
     public function touch()
     {
-        if ((date('U') - $this->getLatestVisit() > $this->delay) && !$this->getIsBot()) {
+        if ((!$this->delay || (date('U') - $this->getLatestVisit() > $this->delay)) && !$this->getIsBot()) {
             if ($this->storeHit()) {
                 $this->increaseCounter();
             }


### PR DESCRIPTION
When you set delay to 0 and have two very fast following hits in less than a second, the second hit will not be counted. This is fixed here.